### PR TITLE
Missing line in the PIL

### DIFF
--- a/src/fibonacci.pil
+++ b/src/fibonacci.pil
@@ -8,3 +8,4 @@ namespace Fibonacci(%N);
     (1-ISLAST) * (aLast' - (aBeforeLast + aLast)) = 0;
 
     public out = aLast(%N-1);
+    ISLAST * (aLast - :out) = 0;


### PR DESCRIPTION
I simply added the constraint checking that the last value of the `aLast` polynomial must be equal to the declared public output `out`.